### PR TITLE
Remove square brackets from AAAA request

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -32,3 +32,4 @@ resource "openstack_dns_recordset_v2" "ipv6_hostname" {
   ]
   depends_on = [openstack_compute_instance_v2.node]
 }
+

--- a/dns.tf
+++ b/dns.tf
@@ -28,8 +28,7 @@ resource "openstack_dns_recordset_v2" "ipv6_hostname" {
   ttl     = 600
   type    = "AAAA"
   records = [
-    element(openstack_compute_instance_v2.node.*.access_ip_v6, count.index)
+    trim(element(openstack_compute_instance_v2.node.*.access_ip_v6, count.index), "[]")
   ]
   depends_on = [openstack_compute_instance_v2.node]
 }
-


### PR DESCRIPTION
Terraform now fails to create AAAA records when the address is embraced by square brackets, ie
      + records              = [
          + "[an IPv6 address]",
        ]

and throws an error message like
"'[an IPv6 address]' is not a 'AAAA' Record"

This change simply removes the square brackets, ie
      + records              = [
          + "an IPv6 address",
        ]

Terraform will then succeed in creating the AAAA record(s).